### PR TITLE
fix ConfigFile constructor

### DIFF
--- a/parse/ConfigFile.cpp
+++ b/parse/ConfigFile.cpp
@@ -1,4 +1,5 @@
 #include "../include/ConfigFile.hpp"
+#include <iostream>
 #include <sstream>
 
 ConfigFile::ConfigFile(void) {
@@ -27,8 +28,13 @@ ConfigFile &ConfigFile::operator=(const ConfigFile &object) {
 }
 
 ConfigFile::ConfigFile(const char *configFilePath) {
-  _setFilePath(configFilePath);
-  _openFile();
+  try {
+    _setFilePath(configFilePath);
+    _openFile();
+  } catch (const std::exception &e) {
+    std::cerr << "Error: " << e.what() << '\n';
+    exit(1);
+  }
 }
 
 void ConfigFile::_setFilePath(const char *configFilePath) {


### PR DESCRIPTION
default configuration 파일이 없을 경우 throw된 exception이 catch 안 되는 부분을 

try-catch문을 통해 예외를 처리하도록 수정하였습니다.